### PR TITLE
Remove <a> tag when a href is empty

### DIFF
--- a/components/japan/News.vue
+++ b/components/japan/News.vue
@@ -22,6 +22,7 @@
             >{{ item.publishedDate }}</time
           >
           <a
+            v-if="item.href !== ''"
             :href="item.href"
             target="_blank"
             rel="noopener"
@@ -29,6 +30,9 @@
           >
             {{ item.text }}
           </a>
+          <span v-else>
+            {{ item.text }}
+          </span>
         </li>
       </ul>
     </div>

--- a/components/japan/UseCases.vue
+++ b/components/japan/UseCases.vue
@@ -7,6 +7,7 @@
       >
         <li v-for="(item, index) in news">
           <a
+            v-if="item.href !== ''"
             :href="item.href"
             target="_blank"
             rel="noopener"
@@ -17,14 +18,6 @@
               data-aos="flip-left"
               :data-aos-delay="index * 100"
             >
-              <!-- <nuxt-img
-                format="webp"
-                quality="90"
-                width="760"
-                class="h-52 w-full object-cover rounded-3xl group-hover:brightness-125"
-                :src="`/use-cases/${item.image}`"
-                :alt="item.title"
-              /> -->
               <img
                 class="h-52 w-full object-cover rounded-3xl group-hover:brightness-125"
                 :src="useAsset('japan/use-cases/' + item.image)"
@@ -37,6 +30,24 @@
               {{ item.title }}
             </p>
           </a>
+          <div v-else>
+            <div
+              class="mb-4"
+              data-aos="flip-left"
+              :data-aos-delay="index * 100"
+            >
+              <img
+                class="h-52 w-full object-cover rounded-3xl group-hover:brightness-125"
+                :src="useAsset('japan/use-cases/' + item.image)"
+                :alt="item.title"
+              />
+            </div>
+            <p
+              class="font-medium mb-2 transition group-hover:underline group-hover:text-blue-600"
+            >
+              {{ item.title }}
+            </p>
+          </div>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
- Remove <a> tag when a href is empty in the news and the use cases section on the Astar Japan Lab page