### PR TITLE
Add GDPR popup using localstrage

### DIFF
--- a/components/Gdpr.vue
+++ b/components/Gdpr.vue
@@ -28,18 +28,16 @@
 </template>
 
 <script setup lang="ts">
-import { useCookies } from "vue3-cookies";
 import { ref } from "vue";
 
-const { cookies } = useCookies();
 const gdpr_accept = ref(false);
 
-if (cookies.get("gdpr") !== null) {
+if (localStorage.getItem("gdpr") !== null) {
   gdpr_accept.value = true;
 }
 
 const acceptCookies = () => {
-  cookies.set("gdpr", "accept", "1y");
+  localStorage.setItem("gdpr", "true");
   gdpr_accept.value = true;
 };
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "gh-pages": "^4.0.0",
         "nuxt": "3.0.0-rc.11",
         "vue3-carousel": "^0.2.5",
-        "vue3-cookies": "^1.0.6",
         "vue3-parallax": "^0.1.4"
       }
     },
@@ -10596,15 +10595,6 @@
         "vue": "^3.2.0"
       }
     },
-    "node_modules/vue3-cookies": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/vue3-cookies/-/vue3-cookies-1.0.6.tgz",
-      "integrity": "sha512-a1UvVD0qIgxyOqjlSOwnLnqAnz8ASltugEv8yX+96i/WGZAN9fEDci7xO4HIWZE1uToUnRq9JnFhvfDCSo45OA==",
-      "dev": true,
-      "dependencies": {
-        "vue": "^3.0.0"
-      }
-    },
     "node_modules/vue3-parallax": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/vue3-parallax/-/vue3-parallax-0.1.4.tgz",
@@ -19077,15 +19067,6 @@
       "integrity": "sha512-G3wty+O4iXPXeZksXvVdNR7EsHXLSIh3IYqz5N5GYRUA7PQ6x9nAtfPqZIfLAyadH4AdeLgMVfMXJhRZlsvyVg==",
       "dev": true,
       "requires": {}
-    },
-    "vue3-cookies": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/vue3-cookies/-/vue3-cookies-1.0.6.tgz",
-      "integrity": "sha512-a1UvVD0qIgxyOqjlSOwnLnqAnz8ASltugEv8yX+96i/WGZAN9fEDci7xO4HIWZE1uToUnRq9JnFhvfDCSo45OA==",
-      "dev": true,
-      "requires": {
-        "vue": "^3.0.0"
-      }
     },
     "vue3-parallax": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "gh-pages": "^4.0.0",
     "nuxt": "3.0.0-rc.11",
     "vue3-carousel": "^0.2.5",
-    "vue3-cookies": "^1.0.6",
     "vue3-parallax": "^0.1.4"
   }
 }


### PR DESCRIPTION
- Fix #12 
- Remove vue-cookies and use localstrage to store GDPR dismissal state