### PR TITLE
Add aspect ration to blog posts images

### DIFF
--- a/components/blog/ArticleCard.vue
+++ b/components/blog/ArticleCard.vue
@@ -8,7 +8,7 @@
       <img
         :src="post.image"
         :alt="post.title"
-        class="object-cover w-full h-[240px] group-hover:brightness-110"
+        class="object-cover w-full aspect-blog group-hover:brightness-110"
         data-not-lazy
       />
       <div class="p-4 sm:p-5 pb-8 sm:pb-12">

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -5,7 +5,7 @@
         <img
           :src="post.image"
           alt=""
-          class="object-cover w-full lg:h-[520px] shadow-xl -my-6 lg:-my-8"
+          class="object-cover w-full aspect-blog max-w-[1280px] shadow-xl -my-6 lg:-my-8"
           data-not-lazy
         />
       </SubPageHeader>

--- a/pages/blog/tag/[tag].vue
+++ b/pages/blog/tag/[tag].vue
@@ -10,7 +10,7 @@
         </h1>
       </SubPageHeader>
 
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 relative z-10">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 relative z-10 mb-12 sm:mb-24">
         <ul
           class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 lg:gap-12"
           v-if="posts.length > 0"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,9 @@ module.exports = {
       "15xl": "14rem",
     },
     extend: {
+      aspectRatio: {
+        'blog': '191.04 / 100',
+      },
       colors: {
         'space-gray':{
           light:"#405FBA",


### PR DESCRIPTION
Added aspect ratio (1280x670 = 191.04 : 100) to blog post images

|BEFORE|AFTER|
|---|---|
|<img width="434" alt="Screenshot 2023-08-02 at 12 11 53 PM" src="https://github.com/AstarNetwork/astarwebsite_v2/assets/33358068/69e84181-03f0-4255-9064-3c706390d53c">|<img width="408" alt="Screenshot 2023-08-02 at 12 14 34 PM" src="https://github.com/AstarNetwork/astarwebsite_v2/assets/33358068/bc4b4582-5ab9-4349-b9a0-33526635471f">|