### PR TITLE
XSS fix for blog tag

### DIFF
--- a/pages/blog/tag/[tag].vue
+++ b/pages/blog/tag/[tag].vue
@@ -41,7 +41,7 @@ import gql from "graphql-tag";
 const localePath = useLocalePath();
 
 const route = useRoute();
-const tag = route.params.tag;
+const tag = encodeURI(route.params.tag);
 
 // The subsocial space for news: https://polkaverse.com/10802 , and Japanese: https://polkaverse.com/11315
 const { locale, t } = useI18n();


### PR DESCRIPTION
Current homepage implementation allows arbitrary script execution through blog tag. This PR is to fix this issue

Before
<img width="773" alt="image" src="https://github.com/AstarNetwork/astarwebsite_v2/assets/8452361/22cdfa55-2bc3-41be-a38a-65ba7703c135">

After (no script executed)
<img width="797" alt="image" src="https://github.com/AstarNetwork/astarwebsite_v2/assets/8452361/42406f7e-c7e0-41fe-bde0-321b989bb58a">
