### PR TITLE
Fix/swanky hub link

### DIFF
--- a/components/developers/Build.vue
+++ b/components/developers/Build.vue
@@ -79,7 +79,7 @@ const building = [
   {
     title: t("developers.start.templates"),
     image: "building-template.svg",
-    href: "https://github.com/swankyhub",
+    href: "https://github.com/inkdevhub",
     color: "bg-space-cyan hover:bg-space-cyan-lighter",
   },
 ];

--- a/components/starmap/Contents.vue
+++ b/components/starmap/Contents.vue
@@ -410,7 +410,7 @@ const discoveries: { [index: string]: Discovery } = {
   swanky: {
     title: t("starmap.expansion.swanky.title"),
     description: `${t("starmap.expansion.swanky.description")}<ul class="list-disc pl-6 my-6"><li>Swanky node</li><li>Swanky CLI</li><li>Swanky dApps</li><li>ink! examples</li></ul>${t("starmap.expansion.swanky.more")}<br><br><strong>${t("starmap.expansion.swanky.welcome")}</strong>`,
-    href: "https://github.com/swankyhub",
+    href: "https://github.com/inkdevhub",
     image: "swanky.svg",
   },
   startale: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "astarwebsite_v2",
       "hasInstallScript": true,
       "dependencies": {
         "markdown-it": "^13.0.1",
@@ -4135,9 +4134,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001482",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
-      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
+      "version": "1.0.30001563",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
+      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
The Swanky Hub URL is outdated. I've replaced it to [ink!DevHub](https://github.com/inkdevhub).

- dApps templates block on the developer page
- Starmap

![image](https://github.com/AstarNetwork/astarwebsite_v2/assets/33358068/d68ab8e4-0774-419a-a00a-ff3e7cf24388)
<img width="1310" alt="Screenshot 2023-11-20 at 9 50 01 PM" src="https://github.com/AstarNetwork/astarwebsite_v2/assets/33358068/680933e0-bcf3-42f4-867d-45865d0eb8b9">
