### PR TITLE
update tokenomics url

### DIFF
--- a/components/home/RecommendedReading.vue
+++ b/components/home/RecommendedReading.vue
@@ -64,7 +64,7 @@ const reading = [
   {
     title: t("home.reading.tokenomics.title"),
     description: t("home.reading.tokenomics.description"),
-    href: "https://docs.astar.network/docs/learn/tokenomics/",
+    href: "https://docs.astar.network/docs/learn/tokenomics2/",
     image: "reading-token.svg",
   },
   {


### PR DESCRIPTION
Updated the URL to the tokenomics 2.0 of docs on the front page

<img width="1309" alt="Screenshot 2024-01-11 at 9 30 16 AM" src="https://github.com/AstarNetwork/astarwebsite_v2/assets/33358068/43c77617-30ba-45ef-b8b6-deb0ad3e9a95">
