### PR TITLE
fix mobile menu link not work

### DIFF
--- a/components/MobileNav.vue
+++ b/components/MobileNav.vue
@@ -98,6 +98,7 @@
                               <NuxtLink
                                 v-for="menu in item.nav"
                                 :key="menu.label"
+                                :href="menu.href"
                                 :target="
                                   menu.href.includes('https')
                                     ? '_blank'


### PR DESCRIPTION
**Pull Request Summary**

> href is missing in the mobile menu

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

- MobileNav href is missing
