### PR TITLE
fix blog detail page when `post.tags` is null

### DIFF
--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -147,6 +147,9 @@ else {
       return
     }
 
+    // when it goes to null, need to set as empty array
+    post.value.tags = post.value.tags ?? []
+
     const orConditions = post.value.tags
       .map(tag => `{ tags: { containsi: "${tag}" } }`)
       .join(', ')


### PR DESCRIPTION
**Pull Request Summary**

> Fix blog detail page

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

- fix blog detail page when `post.tags` is null
